### PR TITLE
Temporarily use custom setup-action without pip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
         with:
           python-version: "3.11"
           install-just: true
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
         with:
           python-version: "3.11"
           install-just: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: "opensafely-core/setup-action@v1"
+    - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
       with:
         python-version: "3.11"
         install-just: true


### PR DESCRIPTION
* setup-action cache currently fails post-run if there is no pip cache directory to cache