### PR TITLE
Do not use pip dependency cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "opensafely-core/setup-action@optional-cache"
         with:
+          cache: null
           python-version: "3.11"
           install-just: true
       - name: Install uv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-# Temp comment
-      - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
+      - uses: "opensafely-core/setup-action@optional-cache"
         with:
           python-version: "3.11"
           install-just: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+# Temp comment
       - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
         with:
           python-version: "3.11"


### PR DESCRIPTION
Experimental PR to try using the [setup-action repo](https://github.com/opensafely-core/setup-action) without a pip cache.

