### PR TITLE
Use published version of setup-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
+      - uses: "opensafely-core/setup-action@v1"
         with:
+          cache: null
           python-version: "3.11"
           install-just: true
       - name: Install uv

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: "opensafely-core/setup-action@8309ec8eb730c5b342dd496a09392f95bedd2fb0"
+    - uses: "opensafely-core/setup-action@v1"
       with:
+        cache: null
         python-version: "3.11"
         install-just: true
     - name: Install uv


### PR DESCRIPTION
This repo uses uv rather than pip, which meant we couldn't use previous published versions of setup-action since it relied on the pip dependency cache.

Version 1.5.0 of setup-action lets repos skip the pip cache, so we can now use that version rather than pinning to an unmerged commit.