### PR TITLE
Fix maintenance mode activation logic

### DIFF
--- a/tests/test_maintenance_mode.py
+++ b/tests/test_maintenance_mode.py
@@ -208,6 +208,27 @@ def create_coded_event_snomed_table(tpp_connection):
             1,
         ),
         (
+            "Swap Table complete but CodedEvent_SNOMED not started",
+            [
+                (
+                    "OpenSAFELY",
+                    "2025-06-12T14:25:10",
+                    "2025-06-12T14:25:10",
+                    "9999-12-31T00:00:00",
+                    None,
+                ),
+                (
+                    "Swap Tables",
+                    "2025-06-12T14:25:10",
+                    "2025-06-12T14:25:10",
+                    "2025-06-12T14:30:10",
+                    None,
+                ),
+            ],
+            True,
+            1,
+        ),
+        (
             "Building CodedEvent_SNOMED",
             [
                 (

--- a/tests/test_maintenance_mode.py
+++ b/tests/test_maintenance_mode.py
@@ -268,11 +268,13 @@ def create_coded_event_snomed_table(tpp_connection):
 def test_in_maintenance_mode(
     tpp_connection,
     build_progress_factory,
+    cleanup_coded_event_snomed_table,
     description,
     events,
     is_in_maintenance_mode,
     expected_build_count,
 ):
+    create_coded_event_snomed_table(tpp_connection)
     for event in events:
         build_progress_factory(event)
     verify_build_progress_count(tpp_connection, events)

--- a/tpp_database_utils/maintenance_mode.py
+++ b/tpp_database_utils/maintenance_mode.py
@@ -51,7 +51,7 @@ def in_maintenance_mode(tpp_connection):
         # No events at all, we can't be in maintenance mode
         return False, 0
 
-    # Of the two most recently started builds, iddentify those that are ongoing (i.e.
+    # Of the two most recently started builds, identify those that are ongoing (i.e.
     # those with an end date of 9999-12-31)
     _, most_recent_end = latest_rebuilds[0]
     if most_recent_end.year < 9999:
@@ -62,19 +62,21 @@ def in_maintenance_mode(tpp_connection):
     ongoing_builds = [rebuild for rebuild in latest_rebuilds if rebuild[1].year == 9999]
     build_count = len(ongoing_builds)
 
-    # Check for incomplete events starting after the start of the earliest ongoing build
+    # Check for events starting on or after the start of the earliest ongoing build
     earliest_build_start_date = min(ongoing_builds)[0]
     cursor.execute(
         "SELECT Event, EventEnd FROM BuildProgress WHERE EventStart >= %s",
         earliest_build_start_date,
     )
-    current_events = {row[0] for row in cursor.fetchall() if row[1].year == 9999}
+    current_events = {row[0] for row in cursor.fetchall()}
 
     # Env var allows quick change of start event logic if needed
     start_events = os.environ.get(
         "TPP_MAINTENANCE_START_EVENT", "Swap Tables,CodedEvent_SNOMED"
     ).split(",")
 
+    # We start maintenance mode as soon as we see any of the "trigger" events
+    # and then don't exit until the entire build is finished
     in_maintenance_mode = bool(current_events.intersection(start_events))
 
     if not in_maintenance_mode:
@@ -85,6 +87,4 @@ def in_maintenance_mode(tpp_connection):
         except ProgrammingError:
             in_maintenance_mode = True
 
-    # We start maintenance mode as soon as we see any of the "trigger" events
-    # and then don't exit until the entire build is finished
     return in_maintenance_mode, build_count


### PR DESCRIPTION
We enter maintenance mode as soon as we see a "Swap Tables" or "CodedEvent_SNOMED" event start.
There is usually a short gap between the "Swap Tables" event completing and the "CodedEvent_SNOMED" event starting, however we want to stay in maintenance mode until the entire build has completed. 

We inadvertently broke this logic in #41 when we extended the code to check for multiple ongoing builds. However because the check runs every 5 minutes and the gap is usually around 5 minutes long we generally managed to miss the gap and didn't immediately notice the problem.

Eventually it manifested as us entering maintenance mode, killing all db jobs, then briefly coming out of it and restarting jobs, and then going back into maintenance and killing them again. Apart from a bit of confusion for tech support, no real harm was done; but we should do the right thing here nonetheless. 

See Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1774366506323779